### PR TITLE
Fix caller reporting when logging via lgr.Default()

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -43,7 +43,7 @@ func Fatalf(format string, args ...interface{}) {
 // Setup default logger with options
 func Setup(opts ...Option) {
 	def = New(opts...)
-	def.callerSkip = 2
+	def.skipCallers = 2
 }
 
 // Default returns pre-constructed def logger (debug off, callers disabled)

--- a/interface.go
+++ b/interface.go
@@ -15,7 +15,7 @@ type L interface {
 // Func type is an adapter to allow the use of ordinary functions as Logger.
 type Func func(format string, args ...interface{})
 
-// Logf calls f(id)
+// Logf calls f(format, args...)
 func (f Func) Logf(format string, args ...interface{}) { f(format, args...) }
 
 // NoOp logger
@@ -26,24 +26,23 @@ var Std = Func(func(format string, args ...interface{}) { stdlog.Printf(format, 
 
 // Printf simplifies replacement of std logger
 func Printf(format string, args ...interface{}) {
-	def.Logf(format, args...)
+	def.logf(format, args...)
 }
 
 // Print simplifies replacement of std logger
 func Print(line string) {
-	def.Logf(line)
+	def.logf(line)
 }
 
 // Fatalf simplifies replacement of std logger
 func Fatalf(format string, args ...interface{}) {
-	def.Logf(format, args...)
+	def.logf(format, args...)
 	os.Exit(1)
 }
 
 // Setup default logger with options
 func Setup(opts ...Option) {
 	def = New(opts...)
-	def.skipCallers = 2
 }
 
 // Default returns pre-constructed def logger (debug off, callers disabled)

--- a/logger.go
+++ b/logger.go
@@ -21,13 +21,12 @@ type Logger struct {
 	callerFile        bool
 	callerFunc        bool
 	callerPkg         bool
-	callerSkip        int
 	ignoredPkgCallers []string
-
-	now         nowFn
-	fatal       panicFn
-	levelBraces bool
-	msec        bool
+	now               nowFn
+	fatal             panicFn
+	skipCallers       int
+	levelBraces       bool
+	msec              bool
 }
 
 type nowFn func() time.Time
@@ -37,11 +36,11 @@ type panicFn func()
 // Two writers can be passed optionally - first for out and second for err
 func New(options ...Option) *Logger {
 	res := Logger{
-		now:        time.Now,
-		fatal:      func() { os.Exit(1) },
-		stdout:     os.Stdout,
-		stderr:     os.Stderr,
-		callerSkip: 1,
+		now:         time.Now,
+		fatal:       func() { os.Exit(1) },
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+		skipCallers: 1,
 	}
 	for _, opt := range options {
 		opt(&res)
@@ -73,7 +72,7 @@ func (l *Logger) Logf(format string, args ...interface{}) {
 	bld.WriteString(" ")
 
 	if l.callerFile || l.callerFunc || l.callerPkg {
-		if pc, file, line, ok := runtime.Caller(l.callerSkip); ok {
+		if pc, file, line, ok := runtime.Caller(l.skipCallers); ok {
 
 			funcName, fileInfo := "", ""
 
@@ -215,14 +214,6 @@ func CallerPkg(l *Logger) {
 func CallerIgnore(ignores ...string) Option {
 	return func(l *Logger) {
 		l.ignoredPkgCallers = ignores
-	}
-}
-
-// CallerSkip sets how many trace levels to skip.
-// by default this value is 1 , i.e. skip logger level only
-func CallerSkip(n int) Option {
-	return func(l *Logger) {
-		l.callerSkip = n
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -24,7 +24,6 @@ type Logger struct {
 	ignoredPkgCallers []string
 	now               nowFn
 	fatal             panicFn
-	skipCallers       int
 	levelBraces       bool
 	msec              bool
 }
@@ -36,11 +35,10 @@ type panicFn func()
 // Two writers can be passed optionally - first for out and second for err
 func New(options ...Option) *Logger {
 	res := Logger{
-		now:         time.Now,
-		fatal:       func() { os.Exit(1) },
-		stdout:      os.Stdout,
-		stderr:      os.Stderr,
-		skipCallers: 1,
+		now:    time.Now,
+		fatal:  func() { os.Exit(1) },
+		stdout: os.Stdout,
+		stderr: os.Stderr,
 	}
 	for _, opt := range options {
 		opt(&res)
@@ -53,6 +51,11 @@ func New(options ...Option) *Logger {
 // ERROR and FATAL also send the same line to err writer.
 // FATAL adds runtime stack and os.exit(1), like panic.
 func (l *Logger) Logf(format string, args ...interface{}) {
+	// to align call depth between (*Logger).Logf() and, for example, Printf()
+	l.logf(format, args...)
+}
+
+func (l *Logger) logf(format string, args ...interface{}) {
 
 	// format timestamp with or without msecs
 	ts := func() (res string) {
@@ -72,7 +75,7 @@ func (l *Logger) Logf(format string, args ...interface{}) {
 	bld.WriteString(" ")
 
 	if l.callerFile || l.callerFunc || l.callerPkg {
-		if pc, file, line, ok := runtime.Caller(l.skipCallers); ok {
+		if pc, file, line, ok := runtime.Caller(2); ok {
 
 			funcName, fileInfo := "", ""
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -149,28 +149,6 @@ func TestLoggerIgnoreCallers(t *testing.T) {
 	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG {lgr/logger_test.go:148 lgr.TestLoggerIgnoreCallers} something 123 err\n", rout.String())
 }
 
-func TestLoggerWithCallerSkip(t *testing.T) {
-	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
-	l := New(Debug, Out(rout), Err(rerr), CallerFunc, Msec, CallerSkip(2))
-	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
-	l.Logf("[DEBUG] something 123 %s", "err")
-	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG {testing.tRunner} something 123 err\n", rout.String())
-
-	rout.Reset()
-	rerr.Reset()
-	l = New(Debug, Out(rout), Err(rerr), CallerFile, CallerFunc, Msec, CallerSkip(0))
-	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
-	l.Logf("[DEBUG] something 123 %s", "err")
-	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG {lgr/logger.go:76 lgr.(*Logger).Logf} something 123 err\n", rout.String())
-
-	rout.Reset()
-	rerr.Reset()
-	l = New(Debug, Out(rout), Err(rerr), CallerPkg, CallerSkip(2))
-	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
-	l.Logf("[DEBUG] something 123 %s", "err")
-	assert.Equal(t, "2018/01/07 13:02:34 DEBUG {testing} something 123 err\n", rout.String())
-}
-
 func TestLoggerWithLevelBraces(t *testing.T) {
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	l := New(Debug, Out(rout), Err(rerr), LevelBraces, Msec)


### PR DESCRIPTION
I suppose the latest commit serves to mitigate wrong package/file/func reporting when logging via `lgr.Default()`. But I think the method you chose to fix the bug is not optimal. You introduce new option to set up call depth by the client. I think this is too complex and **very** strange for a logger. I propose another approach:

- add new method `(*Logger).logf()` to align call depth between `(*Logger).Logf()` and, for example, `Printf()`
- remove `CallerSkip` option
- remove `Logger.callerSkip` field
