### PR TITLE
Add testcase to accomplish #2

### DIFF
--- a/interface_test.go
+++ b/interface_test.go
@@ -72,3 +72,11 @@ func TestDefaultWithSetup(t *testing.T) {
 	Printf("[INFO] something 123 %s", "xyz")
 	assert.Equal(t, "2018/01/07 13:02:34.000 [INFO]  {lgr/interface_test.go:72 lgr.TestDefaultWithSetup} something 123 xyz\n", buff.String())
 }
+
+func TestDefaultFuncWithSetup(t *testing.T) {
+	buff := bytes.NewBuffer([]byte{})
+	Setup(Out(buff), Debug, CallerFile, CallerFunc, Msec, LevelBraces)
+	def.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local) }
+	Default().Logf("[INFO] something 123 %s", "xyz")
+	assert.Equal(t, "2018/01/07 13:02:34.000 [INFO]  {lgr/interface_test.go:80 lgr.TestDefaultFuncWithSetup} something 123 xyz\n", buff.String())
+}


### PR DESCRIPTION
I add a testcase to accomplish #2. The testcase fails on `v0.4.0`.
