### PR TITLE
Refactor caller reporting

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -107,12 +107,12 @@ func (l *Logger) reportCaller(calldepth int) string {
 	}
 
 	filePath, line, funcName := l.caller(calldepth + 1)
+	if (filePath == "") || (line <= 0) || (funcName == "") {
+		return "???"
+	}
 
 	// callerPkg only if no other callers
 	if l.callerPkg && !l.callerFile && !l.callerFunc {
-		if filePath == "" {
-			return "???"
-		}
 		pkgInfo := l.ignoreCaller(filePath)
 		_, pkgInfo = path.Split(path.Dir(pkgInfo))
 		return pkgInfo
@@ -125,9 +125,6 @@ func (l *Logger) reportCaller(calldepth int) string {
 		if pathElems := strings.Split(filePath, "/"); len(pathElems) > 2 {
 			fileInfo = strings.Join(pathElems[len(pathElems)-2:], "/")
 		}
-		if fileInfo == "" {
-			fileInfo = "???"
-		}
 		res += fmt.Sprintf("%s:%d", fileInfo, line)
 		if l.callerFunc {
 			res += " "
@@ -137,9 +134,6 @@ func (l *Logger) reportCaller(calldepth int) string {
 	if l.callerFunc {
 		funcNameElems := strings.Split(funcName, "/")
 		funcInfo := funcNameElems[len(funcNameElems)-1]
-		if funcInfo == "" {
-			funcInfo = "???"
-		}
 		res += funcInfo
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -216,6 +216,23 @@ func TestLoggerConcurrent(t *testing.T) {
 	assert.Equal(t, "", rerr.String())
 }
 
+func TestCaller(t *testing.T) {
+	var l *Logger
+
+	filePath, line, funcName := l.caller(0)
+	assert.True(t, strings.HasSuffix(filePath, "go-pkgz/lgr/logger_test.go"), filePath)
+	assert.Equal(t, 222, line)
+	assert.Equal(t, funcName, "github.com/go-pkgz/lgr.TestCaller")
+
+	f := func() {
+		filePath, line, funcName = l.caller(1)
+	}
+	f()
+	assert.True(t, strings.HasSuffix(filePath, "go-pkgz/lgr/logger_test.go"), filePath)
+	assert.Equal(t, 230, line)
+	assert.Equal(t, funcName, "github.com/go-pkgz/lgr.TestCaller")
+}
+
 func BenchmarkNoDbg(b *testing.B) {
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	l := New(Out(rout), Err(rerr))


### PR DESCRIPTION
I make some refactoring for caller reporting in other to simplify further improvements of the code.

- separate the code for caller reporting
- add checks for edge cases
- don't use `runtime.FuncForPC()` because its usage is [discouraged](https://github.com/golang/go/issues/19426)
