### PR TITLE
Feature:  logging deep callers

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -26,17 +26,17 @@ var Std = Func(func(format string, args ...interface{}) { stdlog.Printf(format, 
 
 // Printf simplifies replacement of std logger
 func Printf(format string, args ...interface{}) {
-	def.logf(format, args...)
+	def.logf(1, format, args...)
 }
 
 // Print simplifies replacement of std logger
 func Print(line string) {
-	def.logf(line)
+	def.logf(1, line)
 }
 
 // Fatalf simplifies replacement of std logger
 func Fatalf(format string, args ...interface{}) {
-	def.logf(format, args...)
+	def.logf(1, format, args...)
 	os.Exit(1)
 }
 
@@ -47,3 +47,11 @@ func Setup(opts ...Option) {
 
 // Default returns pre-constructed def logger (debug off, callers disabled)
 func Default() L { return def }
+
+// DefaultForDepth returns default logger wrapper configured to log callers
+// located calldepth deeper in the stack then the caller of the returned
+// wrapper's Logf() method.
+// calldepth 0 identifying the caller of the Logf() method.
+func DefaultForDepth(calldepth int) L {
+	return def.ForDepth(calldepth)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -233,6 +233,23 @@ func TestCaller(t *testing.T) {
 	assert.Equal(t, funcName, "github.com/go-pkgz/lgr.TestCaller")
 }
 
+func TestLoggerForDepth(t *testing.T) {
+	rout, rerr := &bytes.Buffer{}, &bytes.Buffer{}
+	l := New(Out(rout), Err(rerr), CallerFile, CallerFunc, Msec)
+	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
+
+	l.ForDepth(0).Logf("[ERROR] xxx")
+	assert.Equal(t, "2018/01/07 13:02:34.123 ERROR {lgr/logger_test.go:241 lgr.TestLoggerForDepth} xxx\n", rout.String())
+
+	rout.Reset()
+	rerr.Reset()
+	f := func() {
+		l.ForDepth(1).Logf("[ERROR] xxx")
+	}
+	f()
+	assert.Equal(t, "2018/01/07 13:02:34.123 ERROR {lgr/logger_test.go:249 lgr.TestLoggerForDepth} xxx\n", rout.String())
+}
+
 func BenchmarkNoDbg(b *testing.B) {
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	l := New(Out(rout), Err(rerr))


### PR DESCRIPTION
You mention in #2 that there is a need for logging deep callers. [Example](https://github.com/umputun/remark/blob/034101fb648ea7d731fe37f3fce452e5c202fa2c/backend/app/rest/httperrors.go#L45).
