### PR TITLE
Polish wrapping into the standard logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,14 @@ _Without `lgr.Caller*` it will drop `{caller}` part_
 - `ERROR` sends messages to both out and err writers
 - `PANIC` and `FATAL` send messages to both out and err writers. In addition sends dump of callers and runtime info to err only, and calls `os.Exit(1)`.
 
-### adaptors
+### adaptor
 
-`lgr` logger can be converted to `io.Writer` or `*log.Logger`
+`lgr.L` interface can be converted to `*log.Logger`
 
-- `lgr.ToWriter(l lgr.L, level string) io.Writer` - makes io.Writer forwarding write ops to underlying `lgr.L`
 - `lgr.ToStdLogger(l lgr.L, level string) *log.Logger` - makes standard logger on top of `lgr.L`
 
-_`level` parameter is optional, if defined will enforce the level._    
-  
+_`level` parameter is optional, if defined it will enforce the level._
+
 ### global logger
 
 Users **should avoid** global logger and pass the concrete logger as a dependency. However, in some cases a global logger may be needed, for example migration from stdlib `log` to `lgr`. For such cases `log "github.com/go-pkgz/lgr"` can be imported instead of `log` package.

--- a/adaptor.go
+++ b/adaptor.go
@@ -5,26 +5,24 @@ import (
 	"strings"
 )
 
-// Writer holds lgr.L and wraps with io.Writer interface
-type Writer struct {
-	L
-	level string // if defined added to each message
+// logWriter is an L wrapper for use as an output writer for the standard logger
+type logWriter struct {
+	l L
 }
 
-// Write to lgr.L, trim EOL
-func (w *Writer) Write(p []byte) (n int, err error) {
-	w.Logf(strings.TrimSuffix(w.level+string(p), "\n"))
+// Write implements io.Writer
+func (w logWriter) Write(p []byte) (n int, err error) {
+	w.l.Logf(strings.TrimSuffix(string(p), "\n"))
 	return len(p), nil
 }
 
-// ToWriter makes io.Writer for given lgr.L with optional level
-func ToWriter(l L, level string) *Writer {
+// ToStdLogger returns l wrapped into the standard logger.
+// level is an optional logging level.
+// It is assumed that the returned logger will not be further adjusted
+// (i.e. (*Logger).SetOutput() method will not be called).
+func ToStdLogger(l L, level string) *log.Logger {
 	if level != "" && !strings.HasSuffix(level, " ") {
 		level += " "
 	}
-	return &Writer{l, level}
-}
-
-func ToStdLogger(l L, level string) *log.Logger {
-	return log.New(ToWriter(l, level), "", 0)
+	return log.New(logWriter{l}, level, 0)
 }

--- a/adaptor_test.go
+++ b/adaptor_test.go
@@ -9,24 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAdaptor_ToWriter(t *testing.T) {
+func TestAdaptor_LogWriter(t *testing.T) {
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	l := New(Out(rout), Err(rerr), Msec, LevelBraces)
 	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local) }
 
-	wr := ToWriter(l, "WARN")
-	sz, err := wr.Write([]byte("something blah 123"))
+	wr := logWriter{l}
+	sz, err := wr.Write([]byte("WARN something blah 123"))
 	require.NoError(t, err)
-	assert.Equal(t, 18, sz)
+	assert.Equal(t, 23, sz)
 	assert.Equal(t, "2018/01/07 13:02:34.000 [WARN]  something blah 123\n", rout.String())
 }
 
-func TestAdaptor_ToWriterNoLevel(t *testing.T) {
+func TestAdaptor_LogWriterNoLevel(t *testing.T) {
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	l := New(Out(rout), Err(rerr), Msec, LevelBraces)
 	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local) }
 
-	wr := ToWriter(l, "")
+	wr := logWriter{l}
 	sz, err := wr.Write([]byte("something blah 123"))
 	require.NoError(t, err)
 	assert.Equal(t, 18, sz)


### PR DESCRIPTION
Continuing #7. I think that current implementation of wrapping into the standard logger can be simplified a bit:
- reduce exported funcs/types to just `ToStdLogger()`
- make use of standard logger's `prefix`
