### PR TITLE
fix double logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -165,7 +165,6 @@ func (l *Logger) logf(format string, args ...interface{}) {
 	}
 
 	l.lock.Lock()
-	_, _ = l.stdout.Write(data)
 
 	// write to err as well for high levels, exit(1) on fatal and panic and dump stack on panic level
 	switch lv {
@@ -178,6 +177,8 @@ func (l *Logger) logf(format string, args ...interface{}) {
 		_, _ = l.stderr.Write(data)
 		_, _ = l.stderr.Write(getDump())
 		l.fatal()
+	default:
+		_, _ = l.stdout.Write(data)
 	}
 
 	l.lock.Unlock()


### PR DESCRIPTION
If we exit the program using os.Exit (1), the logger writes the message twice first to stdout, then to stderr. It seems to me it would be appropriate to use default in the switch statement.

Если мы выходим из программы по os.Exit(1), то логгер дважды пишет сообщение сначала в stdout , затем в stderr. Как мне кажется было бы уместным использовать default в операторе switch.