### PR TITLE
Update logger.go

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -300,7 +300,7 @@ func (l *Logger) formatLevel(lv string) string {
 func (l *Logger) extractLevel(line string) (level, msg string) {
 	for _, lv := range levels {
 		if strings.HasPrefix(line, lv) {
-			return lv, line[len(lv)+1:]
+			return lv, strings.TrimSpace(line[len(lv):])
 		}
 		if strings.HasPrefix(line, "["+lv+"]") {
 			return lv, strings.TrimSpace(line[len("["+lv+"]"):])

--- a/logger.go
+++ b/logger.go
@@ -303,7 +303,7 @@ func (l *Logger) extractLevel(line string) (level, msg string) {
 			return lv, line[len(lv)+1:]
 		}
 		if strings.HasPrefix(line, "["+lv+"]") {
-			return lv, line[len(lv)+3:]
+			return lv, strings.TrimSpace(line[len("["+lv+"]"):])
 		}
 	}
 	return "INFO", line


### PR DESCRIPTION
If no space between level prefix and message in log.Printf function (example: [DEBUG]%s) the first character of the message is lost.