### PR TITLE
Mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ and messages elements handled by the same function for a given level.
 
 _A typical use-case is to produce colorful output with a user-define colorization library._
 
+example with [fatih/color](https://github.com/fatih/color):
+
+```go
+	colorizer := lgr.Mapper{
+		ErrorFunc:  func(s string) string { return color.New(color.FgHiRed).Sprint(s) },
+		WarnFunc:   func(s string) string { return color.New(color.FgHiYellow).Sprint(s) },
+		InfoFunc:   func(s string) string { return color.New(color.FgHiWhite).Sprint(s) },
+		DebugFunc:  func(s string) string { return color.New(color.FgWhite).Sprint(s) },
+		CallerFunc: func(s string) string { return color.New(color.FgBlue).Sprint(s) },
+		TimeFunc:   func(s string) string { return color.New(color.FgCyan).Sprint(s) },
+	}
+
+	logOpts := []lgr.Option{lgr.Msec, lgr.LevelBraces, lgr.Map(colorizer)}
+```
 ### adaptors
 
 `lgr` logger can be converted to `io.Writer` or `*log.Logger`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Without `lgr.Caller*` it will drop `{caller}` part_
 - `lgr.Msec` - adds milliseconds to timestamp
 - `lgr.Format` - sets a custom template, overwrite all other formatting modifiers.
 - `lgr.Secret(secret ...)` - sets list of the secrets to hide from the logging outputs.
+- `lgr.Map(mapper)` - sets mapper functions to change elements of the logging output based on levels.
 
 example: `l := lgr.New(lgr.Debug, lgr.Msec)`
 
@@ -78,6 +79,14 @@ _Note: formatter (predefined or custom) adds measurable overhead - the cost will
 - `ERROR` sends messages to both out and err writers
 - `FATAL` and send messages to both out and err writers and exit(1)
 - `PANIC` does the same as `FATAL` but in addition sends dump of callers and runtime info to err.
+
+### mapper
+
+Elements of the output can be altered with a set of user defined function passed as `lgr.Map` options. Such a mapper changes
+the value of an element (i.e. timestamp, level, message, caller) and has separate functions for each level. Note: both level 
+and messages elements handled by the same function for a given level. 
+
+_A typical use-case is to produce colorful output with a user-define colorization library._
 
 ### adaptors
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-pkgz/lgr
 
 require github.com/stretchr/testify v1.5.1
 
-go 1.14
+go 1.15

--- a/logger_test.go
+++ b/logger_test.go
@@ -182,6 +182,74 @@ func TestLogger_formatWithOptions(t *testing.T) {
 	}
 }
 
+func TestLogger_formatWithColors(t *testing.T) {
+	tbl := []struct {
+		opts  []Option
+		elems layout
+		res   string
+	}{
+		{
+			[]Option{},
+			layout{DT: time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local), Message: "blah blah", Level: "INFO "},
+			"!TM=2018/01/07 13:02:34=TM! !IF=INFO =IF! !IF=blah blah=IF!",
+		},
+		{
+			[]Option{Msec},
+			layout{DT: time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local), Message: "blah blah", Level: "DEBUG"},
+			"!TM=2018/01/07 13:02:34.000=TM! !DG=DEBUG=DG! !DG=blah blah=DG!",
+		},
+		{
+			[]Option{Msec, LevelBraces},
+			layout{DT: time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local), Message: "blah blah", Level: "DEBUG"},
+			"!TM=2018/01/07 13:02:34.000=TM! !DG=[DEBUG]=DG! !DG=blah blah=DG!",
+		},
+		{
+			[]Option{CallerFile, Msec},
+			layout{DT: time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local), Message: "blah blah", Level: "DEBUG",
+				CallerFile: "file1.go", CallerLine: 12},
+			"!TM=2018/01/07 13:02:34.000=TM! !DG=DEBUG=DG! !CL={file1.go:12}=CL! !DG=blah blah=DG!",
+		},
+		{
+			[]Option{CallerFunc, CallerPkg},
+			layout{DT: time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local), Message: "blah blah", Level: "DEBUG",
+				CallerFunc: "func1", CallerPkg: "pkg"},
+			"!TM=2018/01/07 13:02:34=TM! !DG=DEBUG=DG! !CL={func1 pkg}=CL! !DG=blah blah=DG!",
+		},
+	}
+
+	mp := Mapper{
+		ErrorFunc: func(s string) string {
+			return "!ER=" + s + "=ER!"
+		},
+		WarnFunc: func(s string) string {
+			return "!WR=" + s + "=WR!"
+		},
+		InfoFunc: func(s string) string {
+			return "!IF=" + s + "=IF!"
+		},
+		DebugFunc: func(s string) string {
+			return "!DG=" + s + "=DG!"
+		},
+		CallerFunc: func(s string) string {
+			return "!CL=" + s + "=CL!"
+		},
+		TimeFunc: func(s string) string {
+			return "!TM=" + s + "=TM!"
+		},
+	}
+
+	for n, tt := range tbl {
+		tt := tt
+		opts := []Option{}
+		opts = append(opts, tt.opts...)
+		opts = append(opts, Map(mp))
+		l := New(opts...)
+		t.Run(strconv.Itoa(n), func(t *testing.T) {
+			assert.Equal(t, tt.res, l.formatWithOptions(tt.elems))
+		})
+	}
+}
+
 func TestLoggerWithPanic(t *testing.T) {
 	fatalCalls := 0
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})

--- a/logger_test.go
+++ b/logger_test.go
@@ -138,6 +138,7 @@ func TestLoggerWithCallerDepth(t *testing.T) {
 		"func2) something 123 err\n", rout.String())
 }
 
+//nolint dupl
 func TestLogger_formatWithOptions(t *testing.T) {
 	tbl := []struct {
 		opts  []Option
@@ -182,6 +183,7 @@ func TestLogger_formatWithOptions(t *testing.T) {
 	}
 }
 
+//nolint dupl
 func TestLogger_formatWithColors(t *testing.T) {
 	tbl := []struct {
 		opts  []Option

--- a/mapper.go
+++ b/mapper.go
@@ -1,0 +1,26 @@
+package lgr
+
+// Mapper defines optional functions to change elements of the logged message for each part, based on levels.
+// Only some mapFunc can be defined, by default does nothing. Can be used to alter the output, for example making some
+// part of the output colorful.
+type Mapper struct {
+	ErrorFunc mapFunc
+	WarnFunc  mapFunc
+	InfoFunc  mapFunc
+	DebugFunc mapFunc
+
+	CallerFunc mapFunc
+	TimeFunc   mapFunc
+}
+
+type mapFunc func(string) string
+
+// nopMapper is a default, doing nothing
+var nopMapper = Mapper{
+	ErrorFunc:  func(s string) string { return s },
+	WarnFunc:   func(s string) string { return s },
+	InfoFunc:   func(s string) string { return s },
+	DebugFunc:  func(s string) string { return s },
+	CallerFunc: func(s string) string { return s },
+	TimeFunc:   func(s string) string { return s },
+}

--- a/options.go
+++ b/options.go
@@ -78,3 +78,10 @@ func Secret(vals ...string) Option {
 		}
 	}
 }
+
+// Map sets mapper functions to change elements of the logged message based on levels.
+func Map(m Mapper) Option {
+	return func(l *Logger) {
+		l.mapper = m
+	}
+}


### PR DESCRIPTION
Add mapping func support

Elements of the output can be altered with a set of user defined function passed as `lgr.Map` options. Such a mapper changes
the value of an element (i.e. timestamp, level, message, caller) and has separate functions for each level. Note: both level 
and messages elements handled by the same function for a given level. 

_A typical use-case is to produce colorful output with a user-define colorization library._

example with [fatih/color](https://github.com/fatih/color):

```go
	colorizer := lgr.Mapper{
		ErrorFunc:  func(s string) string { return color.New(color.FgHiRed).Sprint(s) },
		WarnFunc:   func(s string) string { return color.New(color.FgHiYellow).Sprint(s) },
		InfoFunc:   func(s string) string { return color.New(color.FgHiWhite).Sprint(s) },
		DebugFunc:  func(s string) string { return color.New(color.FgWhite).Sprint(s) },
		CallerFunc: func(s string) string { return color.New(color.FgBlue).Sprint(s) },
		TimeFunc:   func(s string) string { return color.New(color.FgCyan).Sprint(s) },
	}

	logOpts := []lgr.Option{lgr.Msec, lgr.LevelBraces, lgr.Map(colorizer)}
```