### PR TITLE
Add check for difference between stdout/stderr streams

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,22 +53,22 @@ func TestLoggerWithDbg(t *testing.T) {
 		rout, rerr string
 	}{
 		{"aaa", []interface{}{},
-			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) aaa\n", ""},
+			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) aaa\n", ""},
 		{"DEBUG something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
 		{"[DEBUG] something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
 		{"INFO something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
 		{"[INFO] something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
 		{"blah something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) blah something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 INFO  (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) blah something 123 aaa\n", ""},
 		{"WARN something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 WARN  (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
+			"2018/01/07 13:02:34.123 WARN  (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n", ""},
 		{"ERROR something 123 %s", []interface{}{"aaa"},
-			"2018/01/07 13:02:34.123 ERROR (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n",
-			"2018/01/07 13:02:34.123 ERROR (lgr/logger_test.go:81 lgr.TestLoggerWithDbg.func2) something 123 aaa\n"},
+			"2018/01/07 13:02:34.123 ERROR (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n",
+			"2018/01/07 13:02:34.123 ERROR (lgr/logger_test.go:82 lgr.TestLoggerWithDbg.func2) something 123 aaa\n"},
 	}
 
 	rout, rerr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
@@ -97,7 +98,7 @@ func TestLoggerWithDbg(t *testing.T) {
 	rout.Reset()
 	rerr.Reset()
 	l.Logf("[DEBUG] something 123 %s", "err")
-	assert.Equal(t, "2018/01/07 13:02:34.000 DEBUG (lgr/logger_test.go:99) something 123 err\n", rout.String())
+	assert.Equal(t, "2018/01/07 13:02:34.000 DEBUG (lgr/logger_test.go:100) something 123 err\n", rout.String())
 
 	f := `{{.DT.Format "2006/01/02 15:04:05.000"}} {{.Level}} ({{.CallerFunc}}) {{.Message}}`
 	l = New(Debug, Out(rout), Err(rerr), Format(f)) // caller func only
@@ -126,7 +127,7 @@ func TestLoggerWithCallerDepth(t *testing.T) {
 	}
 	f(l1)
 
-	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:127 lgr.TestLoggerWithCallerDepth) something 123 err\n",
+	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:128 lgr.TestLoggerWithCallerDepth) something 123 err\n",
 		rout.String())
 
 	rout.Reset()
@@ -134,11 +135,11 @@ func TestLoggerWithCallerDepth(t *testing.T) {
 	l2 := New(Debug, Out(rout), Err(rerr), Format(FullDebug), CallerDepth(0))
 	l2.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
 	f(l2)
-	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:125 lgr.TestLoggerWithCallerDepth."+
+	assert.Equal(t, "2018/01/07 13:02:34.123 DEBUG (lgr/logger_test.go:126 lgr.TestLoggerWithCallerDepth."+
 		"func2) something 123 err\n", rout.String())
 }
 
-//nolint dupl
+// nolint dupl
 func TestLogger_formatWithOptions(t *testing.T) {
 	tbl := []struct {
 		opts  []Option
@@ -183,7 +184,7 @@ func TestLogger_formatWithOptions(t *testing.T) {
 	}
 }
 
-//nolint dupl
+// nolint dupl
 func TestLogger_formatWithMapper(t *testing.T) {
 	tbl := []struct {
 		opts  []Option
@@ -255,7 +256,7 @@ func TestLogger_formatWithMapper(t *testing.T) {
 	}
 }
 
-//nolint dupl
+// nolint dupl
 func TestLogger_formatWithPartialMapper(t *testing.T) {
 	tbl := []struct {
 		opts  []Option
@@ -363,7 +364,7 @@ func TestLoggerErrorWithDump(t *testing.T) {
 	assert.Equal(t, "2018/01/07 13:02:34.000 ERROR (lgr.TestLoggerErrorWithDump) oh my, error now! bad thing happened", lines[0])
 	assert.Equal(t, ">>> stack trace:", lines[1])
 	assert.Contains(t, lines[2], "github.com/go-pkgz/lgr.TestLoggerErrorWithDump(")
-	assert.Contains(t, lines[3], "lgr/logger_test.go:361")
+	assert.Contains(t, lines[3], "lgr/logger_test.go:362")
 }
 
 func TestLoggerWithErrorSameOutputs(t *testing.T) {
@@ -514,6 +515,35 @@ func TestLoggerHidden(t *testing.T) {
 	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }
 	l.Logf("INFO something password 123 secret xyz")
 	assert.Equal(t, "2018/01/07 13:02:34 INFO  something ****** 123 ****** xyz\n", rout.String(), "secrets secrets")
+}
+
+func TestIsStreamsSameWithStd(t *testing.T) {
+	sout, serr := os.Stdout, os.Stderr
+	assert.True(t, isStreamsSame(sout, serr))
+}
+
+func TestIsStreamsSameWithSameFile(t *testing.T) {
+	dir := t.TempDir()
+	f, _ := os.CreateTemp(dir, "test")
+	assert.True(t, isStreamsSame(f, f))
+}
+
+func TestIsStreamsSameWithDiffFiles(t *testing.T) {
+	dir := t.TempDir()
+	f1, _ := os.CreateTemp(dir, "test")
+	f2, _ := os.CreateTemp(dir, "test")
+	assert.False(t, isStreamsSame(f1, f2))
+}
+
+func TestIsStreamsSameWithSameBuffer(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{})
+	assert.True(t, isStreamsSame(buf, buf))
+}
+
+func TestIsStreamsSameWithDiffBuffer(t *testing.T) {
+	buf1, buf2 := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
+	sout, serr := buf1, buf2
+	assert.False(t, isStreamsSame(sout, serr))
 }
 
 func BenchmarkNoDbgNoFormat(b *testing.B) {


### PR DESCRIPTION
In current behaviour we have this check `l.stderr != l.stdout`. By default, stderr and stdout is `syscall.Stderr` and `syscall.Stdout` which refer to different `fd` but actually refer to the same file(By default, they're probably connected to your terminal device), so this check have no sense in this context and by this reason we have two same log(attached screenshot) what wasn't intentable I think.
I added check for difference between `stdout` and `stderr` to fix this behaviour.
<img width="877" alt="image" src="https://user-images.githubusercontent.com/39978392/195172067-83c6f58e-fa0f-48ff-bc7f-7e3f74b45ed2.png">
