### PR TITLE
Fix SetupWithSlog debug filtering and modernize tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.1.6
 
       - name: install goveralls
         run: GO111MODULE=off go get -u -v github.com/mattn/goveralls

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,103 +1,104 @@
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0.6
-  gocyclo:
-    min-complexity: 15
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-      - rangeValCopy
-
-linters:
-  disable-all: true
-  enable:
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - unparam
-    - unused
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-
-  fast: false
-
-
+version: "2"
 run:
   concurrency: 4
-
-issues:
-  exclude-dirs:
-    - vendor
-  exclude-rules:
-    - text: "should have a package comment, unless it's in another file for this package"
-      linters:
-        - golint
-    - text: "exitAfterDefer:"
-      linters:
-        - gocritic
-    - text: "whyNoLint: include an explanation for nolint directive"
-      linters:
-        - gocritic
-    - text: "go.mongodb.org/mongo-driver/bson/primitive.E"
-      linters:
-        - govet
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - text: "integer overflow conversion"
-      linters:
-        - gosec
-    - text: "should have a package comment"
-      linters:
-        - revive
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "commentedOutCode: may want to remove commented-out code"
-      linters:
-        - gocritic
-    - text: "unnamedResult: consider giving a name to these results"
-      linters:
-        - gocritic
-    - text: "var-naming: don't use an underscore in package name"
-      linters:
-        - revive
-    - text: "should not use underscores in package names"
-      linters:
-        - stylecheck
-    - text: "struct literal uses unkeyed fields"
-      linters:
-        - govet
-    - linters:
-        - unparam
-        - unused
-        - revive
-      path: _test\.go$
-      text: "unused-parameter"
-  exclude-use-default: false
-
+linters:
+  default: none
+  enable:
+    - gochecknoinits
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - nestif
+    - testifylint
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+        - rangeValCopy
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - golint
+        text: should have a package comment, unless it's in another file for this package
+      - linters:
+          - gocritic
+        text: 'exitAfterDefer:'
+      - linters:
+          - gocritic
+        text: 'whyNoLint: include an explanation for nolint directive'
+      - linters:
+          - govet
+        text: go.mongodb.org/mongo-driver/bson/primitive.E
+      - linters:
+          - gosec
+        text: weak cryptographic primitive
+      - linters:
+          - gosec
+        text: integer overflow conversion
+      - linters:
+          - revive
+        text: should have a package comment
+      - linters:
+          - staticcheck
+        text: at least one file in a package should have a package comment
+      - linters:
+          - gocritic
+        text: 'commentedOutCode: may want to remove commented-out code'
+      - linters:
+          - gocritic
+        text: 'unnamedResult: consider giving a name to these results'
+      - linters:
+          - revive
+        text: 'var-naming: don''t use an underscore in package name'
+      - linters:
+          - staticcheck
+        text: should not use underscores in package names
+      - linters:
+          - govet
+        text: struct literal uses unkeyed fields
+      - linters:
+          - revive
+          - unparam
+          - unused
+        path: _test\.go$
+        text: unused-parameter
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/_example/go.mod
+++ b/_example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-pkgz/lgr/_example
 
-go 1.19
+go 1.21
 
 require github.com/go-pkgz/lgr v0.0.0
 

--- a/interface_test.go
+++ b/interface_test.go
@@ -43,7 +43,7 @@ func TestNoOp(t *testing.T) {
 	defer log.SetOutput(os.Stdout)
 
 	NoOp.Logf("blah %s %d something", "str", 123)
-	assert.Equal(t, "", buff.String())
+	assert.Empty(t, buff.String())
 }
 
 func TestDefault(t *testing.T) {
@@ -60,7 +60,7 @@ func TestDefault(t *testing.T) {
 
 	buff.Reset()
 	Printf("[DEBUG] something 123 %s", "xyz")
-	assert.Equal(t, "", buff.String())
+	assert.Empty(t, buff.String())
 
 	buff.Reset()
 	Print("[WARN] something 123 % %% %3A%2F%")

--- a/logger.go
+++ b/logger.go
@@ -253,7 +253,7 @@ func (l *Logger) logf(format string, args ...interface{}) {
 
 func (l *Logger) hideSecrets(data []byte) []byte {
 	for _, h := range l.secrets {
-		data = bytes.Replace(data, h, secretReplacement, -1)
+		data = bytes.ReplaceAll(data, h, secretReplacement)
 	}
 	return data
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -92,7 +92,7 @@ func TestLoggerWithDbg(t *testing.T) {
 	rerr.Reset()
 	l.Logf("[DEBUG] something 123 %s", "err")
 	assert.Equal(t, "2018/01/07 13:02:34.000 DEBUG something 123 err\n", rout.String())
-	assert.Equal(t, "", rerr.String())
+	assert.Empty(t, rerr.String())
 
 	l = New(Debug, Out(rout), Err(rerr), Format(ShortDebug)) // caller file only
 	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 0, time.Local) }
@@ -330,7 +330,7 @@ func TestLoggerWithPanic(t *testing.T) {
 	assert.Equal(t, 1, fatalCalls)
 	assert.Equal(t, "2018/01/07 13:02:34.000 PANIC (lgr.TestLoggerWithPanic) oh my, panic now! bad thing happened\n", rout.String())
 
-	t.Logf(rerr.String()) //nolint:govet
+	t.Log(rerr.String()) //nolint:govet
 	assert.True(t, strings.HasPrefix(rerr.String(), "2018/01/07 13:02:34.000 PANIC"))
 	assert.Contains(t, rerr.String(), "github.com/go-pkgz/lgr.getDump")
 	assert.Contains(t, rerr.String(), "/lgr/logger.go:")
@@ -399,8 +399,8 @@ func TestLoggerConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Equal(t, 1001, len(strings.Split(rout.String(), "\n")))
-	assert.Equal(t, "", rerr.String())
+	assert.Len(t, strings.Split(rout.String(), "\n"), 1001)
+	assert.Empty(t, rerr.String())
 }
 
 func TestLoggerWithLevelBraces(t *testing.T) {
@@ -447,7 +447,7 @@ func TestLoggerWithTrace(t *testing.T) {
 	rout.Reset()
 	rerr.Reset()
 	l.Logf("[TRACE] something 123 %s", "err")
-	assert.Equal(t, "", rout.String())
+	assert.Empty(t, rout.String())
 
 	l = New(Trace, Out(rout), Err(rerr), CallerPkg)
 	l.now = func() time.Time { return time.Date(2018, 1, 7, 13, 2, 34, 123000000, time.Local) }

--- a/slog.go
+++ b/slog.go
@@ -22,7 +22,15 @@ func FromSlogHandler(h slog.Handler) L {
 
 // SetupWithSlog sets up the global logger with a slog logger
 func SetupWithSlog(logger *slog.Logger) {
-	Setup(SlogHandler(logger.Handler()))
+	options := []Option{SlogHandler(logger.Handler())}
+	
+	// check if the slog handler is enabled for debug level
+	// if so, enable debug mode in lgr to prevent filtering
+	if logger.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		options = append(options, Debug)
+	}
+	
+	Setup(options...)
 }
 
 // lgrSlogHandler implements slog.Handler using lgr.L

--- a/slog_test.go
+++ b/slog_test.go
@@ -211,7 +211,7 @@ func TestDirect_SlogHandler(t *testing.T) {
 	// parse and verify output
 	outStr := buff.String()
 	lines := strings.Split(strings.TrimSpace(outStr), "\n")
-	require.Equal(t, 2, len(lines))
+	require.Len(t, lines, 2)
 
 	// verify first message
 	var entry map[string]interface{}
@@ -506,7 +506,7 @@ func TestSlogWithOptions(t *testing.T) {
 		// verify the customized fields are present
 		assert.Equal(t, "DEBUG", entry["severity"], "Should have renamed level field")
 		assert.Equal(t, "test-service", entry["service"], "Should have service attribute")
-		assert.Equal(t, float64(1), entry["version"], "Should have version attribute")
+		assert.InDelta(t, float64(1), entry["version"], 0.001, "Should have version attribute")
 	})
 
 	t.Run("lgr with caller info and json output", func(t *testing.T) {
@@ -785,6 +785,46 @@ func TestSetupWithSlog(t *testing.T) {
 
 	// verify logger was set up correctly
 	assert.Equal(t, "INFO", entry["level"])
+	assert.Equal(t, "message via global logger", entry["msg"])
+	assert.Contains(t, entry, "time")
+}
+
+func TestSetupWithSlogDebug(t *testing.T) {
+	// save original Setup function and restore it after test
+	defer lgr.Setup(lgr.Debug) // just use a simple option to reset
+
+	// create a buffer to capture output
+	buff := bytes.NewBuffer([]byte{})
+
+	// create a slog handler with the buffer
+	jsonHandler := slog.NewJSONHandler(buff, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	// create slog logger with the handler
+	slogLogger := slog.New(jsonHandler)
+
+	// set up global logger with slog
+	lgr.SetupWithSlog(slogLogger)
+
+	// use global logger functions
+	lgr.Printf("DEBUG message via global logger")
+
+	// verify output
+	outStr := buff.String()
+	t.Logf("Global logger output: %s", outStr)
+	t.Logf("Buffer length: %d", len(outStr))
+
+	// parse JSON output
+	if outStr == "" {
+		t.Fatal("Expected output but buffer is empty - DEBUG message was filtered out")
+	}
+	var entry map[string]interface{}
+	err := json.Unmarshal([]byte(outStr), &entry)
+	require.NoError(t, err, "Output should be valid JSON")
+
+	// verify logger was set up correctly
+	assert.Equal(t, "DEBUG", entry["level"])
 	assert.Equal(t, "message via global logger", entry["msg"])
 	assert.Contains(t, entry, "time")
 }


### PR DESCRIPTION
## Summary
- Fix issue #24: SetupWithSlog now properly enables debug mode when slog handler accepts debug level  
- Modernize golangci-lint configuration to v2 format and fix linting issues

## Changes

### Bug Fix (Issue #24)
- Modified `SetupWithSlog` in `slog.go` to check if the slog handler is enabled for debug level
- If debug is enabled in slog, the `Debug` option is added to lgr to prevent filtering DEBUG messages
- Added test `TestSetupWithSlogDebug` to verify the fix

### Modernization
- Migrated `.golangci.yml` to v2 format using `golangci-lint migrate`
- Updated GitHub workflow to use `golangci-lint-action@v7` with version `v2.1.6`
- Fixed linting issues:
  - Changed `bytes.Replace` to `bytes.ReplaceAll` in `logger.go`
  - Updated test assertions to use `assert.Empty`, `assert.Len`, and `assert.InDelta` where appropriate
- Removed deprecated linters (golint, maligned) from configuration

## Test plan
- [x] Run the new test `TestSetupWithSlogDebug` - passes
- [x] Run all tests with `go test ./...` - all pass
- [x] Run golangci-lint v2 - no issues
- [x] Verify existing functionality is not affected